### PR TITLE
Bump minimum CMake version to avoid CMP0048 on Noetic buildfarm

### DIFF
--- a/ixblue_ins/CMakeLists.txt
+++ b/ixblue_ins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ixblue_ins)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/ixblue_ins_driver/CMakeLists.txt
+++ b/ixblue_ins_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ixblue_ins_driver)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/ixblue_ins_msgs/CMakeLists.txt
+++ b/ixblue_ins_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ixblue_ins_msgs)
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
See: https://answers.ros.org/question/361001/how-to-fix-unstable-build-on-buildfarm-for-noetic-because-of-cmp0048/?answer=361002#post-id-361002