### PR TITLE
Wrap longitude in [-180,180] to follow sensor_msgs/NavSatFix.msg

### DIFF
--- a/ixblue_ins_driver/src/ros_publisher.cpp
+++ b/ixblue_ins_driver/src/ros_publisher.cpp
@@ -299,6 +299,11 @@ ROSPublisher::toNavSatFixMsg(const ixblue_stdbin_decoder::Data::BinaryNav& navDa
     // --- Position
     res->latitude = navData.position.get().latitude_deg;
     res->longitude = navData.position.get().longitude_deg;
+    // stdbin output in [0; 360[ but NavSatFix must be in [-180; +180]
+    if(res->longitude > 180.0)
+    {
+        res->longitude -= 360.0;
+    }
     res->altitude = navData.position.get().altitude_m;
 
     // --- Position SD

--- a/ixblue_ins_driver/test/test_ixblue_ins_driver.cpp
+++ b/ixblue_ins_driver/test/test_ixblue_ins_driver.cpp
@@ -55,6 +55,25 @@ TEST(ROSPublisherTester, CanFillANavSatFixMsgButNoCovarianceIfNoPositionDeviatio
     EXPECT_EQ(msg->position_covariance_type, sensor_msgs::NavSatFix::COVARIANCE_TYPE_UNKNOWN);
 }
 
+TEST(ROSPublisherTester, CanFillANavSatFixMsgWithWestLong)
+{
+    ixblue_stdbin_decoder::Data::Position pos;
+    pos.latitude_deg = -23.454; // stdbin output [-90°,+90°]
+    pos.longitude_deg = 270.34; // stdbin output [0°,360°[
+    pos.altitude_m = 123.456;
+
+    ixblue_stdbin_decoder::Data::BinaryNav nav;
+    nav.position = pos;
+
+    const sensor_msgs::NavSatFixPtr msg = ROSPublisher::toNavSatFixMsg(nav);
+    ASSERT_NE(msg, nullptr);
+    EXPECT_EQ(msg->latitude, -23.454);
+    EXPECT_DOUBLE_EQ(msg->longitude, -89.66);
+    EXPECT_EQ(msg->altitude, pos.altitude_m);
+    EXPECT_EQ(msg->position_covariance_type,
+              sensor_msgs::NavSatFix::COVARIANCE_TYPE_UNKNOWN);
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Fix #12

Another implementation to avoid the `angles` dependency and avoid the radians conversion could be:

```c++
if(res->longitude > 180.0)
{
    res->longitude  - 360.0;
}
```

@adrienbarral and @1r0b1n0 which one do you prefer?